### PR TITLE
Remove nondata ids from API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Labor Statistics
 
-- **laborstatsid**:**float** - _serialized primary key_
 - **fips**:**integer** - _foreign key, references counties(fips)_
 - **laborforce**:**float** - _civilian labor force_
 - **employed**:**float** - _employed_
@@ -184,7 +183,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Wage Statistics
 
-- **wagestatsid**:**integer** - _serialized primary key_
 - **fips**:**integer** - _foreign key, references counties(fips)_
 - **medianwage**:**float** - _2012 Median Wage_
 - **medianhourly**:**float** - _2012 Median Wage - Hourly_
@@ -201,7 +199,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Calculated Statistics
 
-- **calculatedstatsid**:**integer** -	_serialized primary key_
 - **fips**:**integer** - _foreign key, references counties(fips)_
 - **percentorkids**:**float** - _Percentage of State's kids_
 - **a1allper**:**float** - _percentage Single Adults with and without children_
@@ -210,7 +207,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Self-Sufficiency Standard Budget
 
-- **sssbudgetid**:**integer** - _serialized primary key_
 - **familycode**:**string** - _foreign key, references familytype(familycode)_
 - **housing**:**float** - _monthly cost of housing_
 - **childcare**:**float** - _monthly cost of childcare_
@@ -224,7 +220,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Self-Sufficiency Standard Tax Credits
 
-- **ssscreditsid**:**integer** - _serialized primary key_
 - **familycode**:**string** - _foreign key, references familytype(familycode)_
 - **oregonworkingfamilychildcare**:**float** - _amount that can be deducted monthly for oregon working family childcare tax credit (stored as negative value)_
 - **earnedincometax**:**float** - _amount that can be deducted monthly for earned income tax credit (stored as negative value)_
@@ -235,7 +230,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### Self-Sufficiency Standard Wages
 
-- **ssswageid**:**integer** - _serialized primary key_
 - **familycode**:**string** - _foreign key, references familytype(familycode)_
 - **hourly**:**float** - _hourly self sufficiency standard wage_
 - **qualifier**:**text** - _describes whether wage applies to individuals or couples_
@@ -246,7 +240,6 @@ _Many of these field names will likely be refactored so that fields like "a1c1C"
 
 #### PUMA codes
 
-- **pumafipsid**:**integer** - _serialized primary key_
 - **fips**:**integer** - _foreign key, references counties(fips)_
 - **pumacode**:**integer** - _puma code_
 - **areaname**:**text** - _short name of puma area_

--- a/jobs-economy/app/api/models.py
+++ b/jobs-economy/app/api/models.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from app import db
-from sqlalchemy import text
+
 
 class CalculatedStats(db.Model):
     __tablename__ = 'calculatedstats'

--- a/jobs-economy/app/api/query.py
+++ b/jobs-economy/app/api/query.py
@@ -90,18 +90,18 @@ def construct_laborstats_for_county(fips):
 def construct_population_all():
     return [
         {
-              "fips": stat.fips,
-              "population": stat.population,
-              "adults": stat.adults,
-              "kids": stat.kids,
-              "kidspresentc": stat.kidspresentc,
-              "a1cC": stat.a1cc,
-              "a2s2C": stat.a2s2c,
-              "a1c0C": stat.a1c0c,
-              "a1teenC": stat.a1teenc,
-              "mindiff": stat.mindiff,
-              "mostcommonfamilytype": stat.mostcommonfamilytype,
-              "year": stat.year
+          "fips": stat.fips,
+          "population": stat.population,
+          "adults": stat.adults,
+          "kids": stat.kids,
+          "kidspresentc": stat.kidspresentc,
+          "a1cC": stat.a1cc,
+          "a2s2C": stat.a2s2c,
+          "a1c0C": stat.a1c0c,
+          "a1teenC": stat.a1teenc,
+          "mindiff": stat.mindiff,
+          "mostcommonfamilytype": stat.mostcommonfamilytype,
+          "year": stat.year
         } for stat in models.Population.query]
 
 
@@ -208,7 +208,6 @@ def construct_calculatedstats_for_county(fips):
 def construct_sssbudget_all():
     return [
         {
-            "sssbudgetid": stat.sssbudgetid,
             "familycode": stat.familycode,
             "fips": stat.fips,
             "housing": stat.housing,
@@ -226,7 +225,6 @@ def construct_sssbudget_all():
 def construct_sssbudget_for_county(fips):
     stat = models.SssBudget.query.filter_by(fips=fips).first_or_404()
     return {
-        "sssbudgetid": stat.sssbudgetid,
         "familycode": stat.familycode,
         "housing": stat.housing,
         "childcare": stat.childcare,
@@ -244,7 +242,6 @@ def construct_sssbudget_for_county(fips):
 def construct_ssscredits_all():
     return [
         {
-            "ssscreditsid": stat.ssscreditsid,
             "familycode": stat.familycode,
             "oregonworkingfamilycredit": stat.oregonworkingfamilycredit,
             "earnedincometax": stat.earnedincometax,
@@ -259,7 +256,6 @@ def construct_ssscredits_all():
 def construct_ssscredits_for_county(fips):
     stat = models.SssCredits.query.filter_by(fips=fips).first_or_404()
     return {
-        "ssscreditsid": stat.ssscreditsid,
         "familycode": stat.familycode,
         "oregonworkingfamilycredit": stat.oregonworkingfamilycredit,
         "earnedincometax": stat.earnedincometax,
@@ -274,7 +270,6 @@ def construct_ssscredits_for_county(fips):
 def construct_ssswages_all():
     return [
         {
-            "ssswagesid": stat.ssswagesid,
             "familycode": stat.familycode,
             "hourly": stat.hourly,
             "qualifier": stat.qualifier,
@@ -289,7 +284,6 @@ def construct_ssswages_all():
 def construct_ssswages_for_county(fips):
     stat = models.SssWages.query.filter_by(fips=fips).first_or_404()
     return {
-        "ssswagesid": stat.ssswagesid,
         "familycode": stat.familycode,
         "hourly": stat.hourly,
         "qualifier": stat.qualifier,
@@ -304,7 +298,6 @@ def construct_ssswages_for_county(fips):
 def construct_puma_all():
     return [
         {
-            "pumafipsid": stat.pumafipsid,
             "fips": stat.fips,
             "pumacode": stat.pumacode,
             "areaname": stat.areaname,
@@ -319,7 +312,6 @@ def construct_puma_all():
 def construct_puma_for_county(fips):
     stat = models.Puma.query.filter_by(fips=fips).first_or_404()
     return {
-        "pumafipsid": stat.pumafipsid,
         "fips": stat.fips,
         "pumacode": stat.pumacode,
         "areaname": stat.areaname,

--- a/jobs-economy/tests/test_api.py
+++ b/jobs-economy/tests/test_api.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import app
 from app.api import models
 
+
 class ApiTestCase(unittest.TestCase):
     def setUp(self):
         app.app.config['TESTING'] = True
@@ -41,11 +42,68 @@ class PopulationTestCase(ApiTestCase):
 
     def test_county_fips(self):
         self.db.session.add(models.County(fips=1234, county="Abc"))
-        self.db.session.add(models.CalculatedStats(fips=1234,
+        self.db.session.add(models.CalculatedStats(
+            fips=1234,
             percentorkids=0.1,
             a1allper=0.2,
             a2allper=0.3,
             c0allper=0.4))
+        self.db.session.add(models.LaborStats(
+            fips=1234,
+            laborforce=0.1,
+            employed=0.2,
+            unemployed=0.3,
+            unemploymentrate=0.4,
+            urseasonaladj=0.5,
+            year=2012
+            ))
+        self.db.session.add(models.Population(
+            fips=1234,
+            population=0.1,
+            adults=0.2,
+            kids=0.3,
+            kidspresentc=0.4,
+            a1cc=0.5,
+            a2s2c=0.6,
+            a1c0c=0.7,
+            a1teenc=0.8,
+            kidspresentcper=0.9,
+            a1ccper=0.11,
+            a2s2cper=0.12,
+            a1c0cper=0.13,
+            a1teencper=0.14,
+            mindiff=0.15,
+            mostcommonfamilytype='a1i0p0s0t0',
+            year=2012
+            ))
+        self.db.session.add(models.WageStats(
+            fips=1234,
+            medianwage=0.1,
+            medianhourly=0.2,
+            lessthan10hour=0.3,
+            btwn10and15hour=0.4,
+            totalunder15=0.5,
+            totalpercentorjobs=0.6,
+            countysalary=0.7,
+            countywage=0.8,
+            countywageh2=0.9,
+            countywagerank=0.11,
+            countywageh2rank=0.12,
+            year=2012
+        ))
+        self.db.session.add(models.SssBudget(
+            familycode='a1i0p0s0t0',
+            housing=0.1,
+            childcare=0.2,
+            food=0.3,
+            transportation=0.4,
+            healthcare=0.5,
+            miscellaneous=0.6,
+            taxes=0.7,
+            fips=1234,
+            year=2012
+        ))
+        self.db.session.add(models.Sss)
 
         self.db.session.commit()
         self.assert_json_equal('/counties/1234', {


### PR DESCRIPTION
I removed the ids (like wagestatsid, pumafipsid, etc.) from that don't have any significance to the data.
I've also started fleshing out the unit tests.

Note on models.py: Flake8 told me that "text" was imported but unused, so I removed it. 
