### PR TITLE
Pluralize resource names

### DIFF
--- a/jobs-economy/app/api/controllers.py
+++ b/jobs-economy/app/api/controllers.py
@@ -80,22 +80,22 @@ def laborstats_for_county(fips):
     return query.construct_laborstats_for_county(fips)
 
 
-@api.route('counties/population', methods=['GET'])
+@api.route('counties/populations', methods=['GET'])
 @crossdomain(origin='*')
-def population_all():
-    return query.construct_population_all()
+def populations_all():
+    return query.construct_populations_all()
 
 
-@api.route('counties/<int:fips>/population', methods=['GET'])
+@api.route('counties/<int:fips>/populations', methods=['GET'])
 @crossdomain(origin='*')
-def population_for_county(fips):
-    return query.construct_population_for_county(fips)
+def populations_for_county(fips):
+    return query.construct_populations_for_county(fips)
 
 
-@api.route('counties/familytype', methods=['GET'])
+@api.route('counties/familytypes', methods=['GET'])
 @crossdomain(origin='*')
-def familytype_all():
-    return query.construct_familytype_all()
+def familytypes_all():
+    return query.construct_familytypes_all()
 
 
 @api.route('counties/wagestats', methods=['GET'])
@@ -123,16 +123,16 @@ def calculatedstats_for_county(fips):
     return query.construct_calculatedstats_for_county(fips)
 
 
-@api.route('counties/sssbudget', methods=['GET'])
+@api.route('counties/sssbudgets', methods=['GET'])
 @crossdomain(origin='*')
-def sssbudget_all():
-    return query.construct_sssbudget_all()
+def sssbudgets_all():
+    return query.construct_sssbudgets_all()
 
 
-@api.route('counties/<int:fips>/sssbudget', methods=['GET'])
+@api.route('counties/<int:fips>/sssbudgets', methods=['GET'])
 @crossdomain(origin='*')
-def sssbudget_for_county(fips):
-    return query.construct_sssbudget_for_county(fips)
+def sssbudgets_for_county(fips):
+    return query.construct_sssbudgets_for_county(fips)
 
 
 @api.route('counties/ssscredits', methods=['GET'])
@@ -159,40 +159,40 @@ def ssswages_for_county(fips):
     return query.construct_ssswages_for_county(fips)
 
 
-@api.route('counties/puma', methods=['GET'])
+@api.route('counties/pumas', methods=['GET'])
 @crossdomain(origin='*')
-def puma_all():
-    return query.construct_puma_all()
+def pumas_all():
+    return query.construct_pumas_all()
 
 
-@api.route('counties/<int:fips>/puma', methods=['GET'])
+@api.route('counties/<int:fips>/pumas', methods=['GET'])
 @crossdomain(origin='*')
-def puma_for_county(fips):
-    return query.construct_puma_for_county(fips)
+def pumas_for_county(fips):
+    return query.construct_pumas_for_county(fips)
 
 
-@api.route('counties/censushousehold', methods=['GET'])
+@api.route('counties/censushouseholds', methods=['GET'])
 @crossdomain(origin='*')
-def censushousehold_all():
-    return query.construct_censushousehold_all()
+def censushouseholds_all():
+    return query.construct_censushouseholds_all()
 
 
-@api.route('counties/<int:fips>/censushousehold', methods=['GET'])
+@api.route('counties/<int:fips>/censushouseholds', methods=['GET'])
 @crossdomain(origin='*')
-def censushousehold_for_county(fips):
-    return query.construct_censushousehold_for_county(fips)
+def censushouseholds_for_county(fips):
+    return query.construct_censushouseholds_for_county(fips)
 
 
-@api.route('counties/familycodeweight', methods=['GET'])
+@api.route('counties/familycodeweights', methods=['GET'])
 @crossdomain(origin='*')
-def familycodeweight_all():
-    return query.construct_familycodeweight_all()
+def familycodeweights_all():
+    return query.construct_familycodeweights_all()
 
 
-@api.route('counties/<int:fips>/familycodeweight', methods=['GET'])
+@api.route('counties/<int:fips>/familycodeweights', methods=['GET'])
 @crossdomain(origin='*')
-def familycodeweight_for_county(fips):
-    return query.construct_familycodeweight_for_county(fips)
+def familycodeweights_for_county(fips):
+    return query.construct_familycodeweights_for_county(fips)
 
 
 @api.errorhandler(404)

--- a/jobs-economy/app/api/models.py
+++ b/jobs-economy/app/api/models.py
@@ -154,7 +154,7 @@ class SssWages(db.Model):
     county = db.relationship(u'County',
         backref=db.backref('sss_wages', lazy="dynamic"))
 
-
+#TODO: update WageStats model with new csv data
 class WageStats(db.Model):
     __tablename__ = 'wagestats'
 
@@ -180,15 +180,24 @@ class WageStats(db.Model):
 class CensusHousehold(db.Model):
     __tablename__ = 'censushousehold'
 
-    id = db.Column(db.Integer, primary_key=True)
+    censushouseholdid = db.Column(db.Integer, primary_key=True)
     fips = db.Column(db.ForeignKey(u'counties.fips'))
-    lowincomesingleadults = db.Column(db.Integer)
-    totalsingleadults = db.Column(db.Integer)
-    lowincomesingleparents = db.Column(db.Integer)
-    totalsingleparents = db.Column(db.Integer)
-    lowincomemarriedparents = db.Column(db.Integer)
-    totalmarriedparents = db.Column(db.Integer)
     totalhouseholds = db.Column(db.Integer)
+    totalmarriedfamilyhouseholds = db.Column(db.Integer)
+    totalnonfamilyhouseholds = db.Column(db.Integer)
+    totalunmarriedfamilyhouseholds = db.Column(db.Integer)
+    lowincomesingleparents = db.Column(db.Integer)
+    lowincomemarriedparents = db.Column(db.Integer)
+    lowincomesingleadults = db.Column(db.Integer)
+    marriedaspercenttotal = db.Column(db.Float)
+    lowincomemarriedparentsaspercenttotal = db.Column(db.Float)
+    lowincomemarriedparentsaspercentmarried = db.Column(db.Float)
+    unmarriedaspercenttotal = db.Column(db.Float)
+    lowincomesingleparentsaspercenttotal = db.Column(db.Float)
+    lowincomesingleparentsaspercentunmarried = db.Column(db.Float)
+    nonfamilyaspercenttotal = db.Column(db.Float)
+    lowincomesingleadultsaspercenttotal = db.Column(db.Float)
+    lowincomesingleadultsaspercentnonfamily = db.Column(db.Float)
 
     county = db.relationship(u'County',
         backref=db.backref('census_household', lazy="dynamic"))

--- a/jobs-economy/app/api/query.py
+++ b/jobs-economy/app/api/query.py
@@ -46,7 +46,8 @@ def construct_county(fips):
         'sssBudget': construct_sssbudget_for_county.__wrapped__(fips),
         'sssCredits': construct_ssscredits_for_county.__wrapped__(fips),
         'sssWages': construct_ssswages_for_county.__wrapped__(fips),
-        'censusHousehold': construct_censushousehold_for_county.__wrapped__(fips),
+        'censusHouseholds': construct_censushousehold_for_county.__wrapped__(fips),
+        'familyCodeWeights': construct_familycodeweight_for_county.__wrapped__(fips),
     }
 
 
@@ -338,13 +339,22 @@ def construct_censushousehold_all():
     return [
         {
             "fips": stat.fips,
-            "lowIncomeSingleAdults": stat.lowincomesingleadults,
-            "totalSingleAdults": stat.totalsingleadults,
+            "totalHouseholds": stat.totalhouseholds,
+            "totalMarriedFamilyHouseholds": stat.totalmarriedfamilyhouseholds,
+            "totalNonFamilyHouseholds": stat.totalnonfamilyhouseholds,
+            "totalUnmarriedFamilyHouseholds": stat.totalunmarriedfamilyhouseholds,
             "lowIncomeSingleParents": stat.lowincomesingleparents,
-            "totalSingleParents": stat.totalsingleparents,
             "lowIncomeMarriedParents": stat.lowincomemarriedparents,
-            "totalMarriedParents": stat.totalmarriedparents,
-            "totalHouseHolds": stat.totalhouseholds
+            "lowIncomeSingleAdults": stat.lowincomesingleadults,
+            "marriedAsPercentTotal": stat.marriedaspercenttotal,
+            "lowIncomeMarriedParentsAsPercentTotal": stat.lowincomemarriedparentsaspercenttotal,
+            "lowIncomeMarriedParentsAsPercentMarried": stat.lowincomemarriedparentsaspercentmarried,
+            "unmarriedAsPercentTotal": stat.unmarriedaspercenttotal,
+            "lowIncomeSingleParentsAsPercentTotal": stat.lowincomesingleparentsaspercenttotal,
+            "lowIncomeSingleParentsAsPercentUnmarried": stat.lowincomesingleparentsaspercentunmarried,
+            "nonFamilyAsPercentTotal": stat.nonfamilyaspercenttotal,
+            "lowIncomeSingleAdultsAsPercentTotal": stat.lowincomesingleadultsaspercenttotal,
+            "lowIncomeSingleAdultsAsPercentNonFamily": stat.lowincomesingleadultsaspercentnonfamily,
         } for stat in models.CensusHousehold.query]
 
 
@@ -353,13 +363,22 @@ def construct_censushousehold_for_county(fips):
     stat = models.CensusHousehold.query.filter_by(fips=fips).first_or_404()
     return {
         "fips": stat.fips,
-        "lowIncomeSingleAdults": stat.lowincomesingleadults,
-        "totalSingleAdults": stat.totalsingleadults,
+        "totalHouseholds": stat.totalhouseholds,
+        "totalMarriedFamilyHouseholds": stat.totalmarriedfamilyhouseholds,
+        "totalNonFamilyHouseholds": stat.totalnonfamilyhouseholds,
+        "totalUnmarriedFamilyHouseholds": stat.totalunmarriedfamilyhouseholds,
         "lowIncomeSingleParents": stat.lowincomesingleparents,
-        "totalSingleParents": stat.totalsingleparents,
         "lowIncomeMarriedParents": stat.lowincomemarriedparents,
-        "totalMarriedParents": stat.totalmarriedparents,
-        "totalHouseHolds": stat.totalhouseholds
+        "lowIncomeSingleAdults": stat.lowincomesingleadults,
+        "marriedAsPercentTotal": stat.marriedaspercenttotal,
+        "lowIncomeMarriedParentsAsPercentTotal": stat.lowincomemarriedparentsaspercenttotal,
+        "lowIncomeMarriedParentsAsPercentMarried": stat.lowincomemarriedparentsaspercentmarried,
+        "unmarriedAsPercentTotal": stat.unmarriedaspercenttotal,
+        "lowIncomeSingleParentsAsPercentTotal": stat.lowincomesingleparentsaspercenttotal,
+        "lowIncomeSingleParentsAsPercentUnmarried": stat.lowincomesingleparentsaspercentunmarried,
+        "nonFamilyAsPercentTotal": stat.nonfamilyaspercenttotal,
+        "lowIncomeSingleAdultsAsPercentTotal": stat.lowincomesingleadultsaspercenttotal,
+        "lowIncomeSingleAdultsAsPercentNonFamily": stat.lowincomesingleadultsaspercentnonfamily,
     }
 
 
@@ -368,7 +387,7 @@ def construct_familycodeweight_all():
     return [
         {
             "fips": stat.fips,
-            "familycode": stat.familycode,
+            "familyCode": stat.familycode,
             "weight": stat.weight,
         }
         for stat in models.FamilyCodeWeight.query]
@@ -379,7 +398,7 @@ def construct_familycodeweight_for_county(fips):
     return [
         {
             "fips": stat.fips,
-            "familycode": stat.familycode,
+            "familyCode": stat.familycode,
             "weight": stat.weight,
         }
         for stat in models.FamilyCodeWeight.query.filter_by(fips=fips)]

--- a/jobs-economy/app/api/query.py
+++ b/jobs-economy/app/api/query.py
@@ -40,14 +40,14 @@ def clear_caches():
 def construct_county(fips):
     return {
         'laborStats': construct_laborstats_for_county.__wrapped__(fips),
-        'population': construct_population_for_county.__wrapped__(fips),
+        'populations': construct_populations_for_county.__wrapped__(fips),
         'wageStats': construct_wagestats_for_county.__wrapped__(fips),
         'calculatedStats': construct_calculatedstats_for_county.__wrapped__(fips),
-        'sssBudget': construct_sssbudget_for_county.__wrapped__(fips),
+        'sssBudgets': construct_sssbudgets_for_county.__wrapped__(fips),
         'sssCredits': construct_ssscredits_for_county.__wrapped__(fips),
         'sssWages': construct_ssswages_for_county.__wrapped__(fips),
-        'censusHouseholds': construct_censushousehold_for_county.__wrapped__(fips),
-        'familyCodeWeights': construct_familycodeweight_for_county.__wrapped__(fips),
+        'censusHouseholds': construct_censushouseholds_for_county.__wrapped__(fips),
+        'familyCodeWeights': construct_familycodeweights_for_county.__wrapped__(fips),
     }
 
 
@@ -89,7 +89,7 @@ def construct_laborstats_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_population_all():
+def construct_populations_all():
     return [
         {
             "fips": stat.fips,
@@ -113,7 +113,7 @@ def construct_population_all():
 
 
 @jsonify_lru_cache()
-def construct_population_for_county(fips):
+def construct_populations_for_county(fips):
     stat = models.Population.query.filter_by(fips=fips).first_or_404()
     return {
         "fips": stat.fips,
@@ -137,7 +137,7 @@ def construct_population_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_familytype_all():
+def construct_familytypes_all():
     return [
         {
             "familyCode": stat.familycode,
@@ -218,7 +218,7 @@ def construct_calculatedstats_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_sssbudget_all():
+def construct_sssbudgets_all():
     return [
         {
             "familyCode": stat.familycode,
@@ -235,7 +235,7 @@ def construct_sssbudget_all():
 
 
 @jsonify_lru_cache()
-def construct_sssbudget_for_county(fips):
+def construct_sssbudgets_for_county(fips):
     return [
         {
             "familyCode": stat.familycode,
@@ -308,7 +308,7 @@ def construct_ssswages_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_puma_all():
+def construct_pumas_all():
     return [
         {
             "fips": stat.fips,
@@ -322,7 +322,7 @@ def construct_puma_all():
 
 
 @jsonify_lru_cache()
-def construct_puma_for_county(fips):
+def construct_pumas_for_county(fips):
     return [
         {
             "fips": stat.fips,
@@ -335,7 +335,7 @@ def construct_puma_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_censushousehold_all():
+def construct_censushouseholds_all():
     return [
         {
             "fips": stat.fips,
@@ -359,7 +359,7 @@ def construct_censushousehold_all():
 
 
 @jsonify_lru_cache()
-def construct_censushousehold_for_county(fips):
+def construct_censushouseholds_for_county(fips):
     stat = models.CensusHousehold.query.filter_by(fips=fips).first_or_404()
     return {
         "fips": stat.fips,
@@ -383,7 +383,7 @@ def construct_censushousehold_for_county(fips):
 
 
 @jsonify_lru_cache()
-def construct_familycodeweight_all():
+def construct_familycodeweights_all():
     return [
         {
             "fips": stat.fips,
@@ -394,7 +394,7 @@ def construct_familycodeweight_all():
 
 
 @jsonify_lru_cache()
-def construct_familycodeweight_for_county(fips):
+def construct_familycodeweights_for_county(fips):
     return [
         {
             "fips": stat.fips,

--- a/jobs-economy/tests/test_api.py
+++ b/jobs-economy/tests/test_api.py
@@ -160,7 +160,7 @@ class PopulationTestCase(ApiTestCase):
                     'urSeasonalAdj': 0.5,
                     'year': 2012
                 },
-                'population': {
+                'populations': {
                     'fips': 1234,
                     'population': 0.1,
                     'adults': 0.2,
@@ -201,7 +201,7 @@ class PopulationTestCase(ApiTestCase):
                     'a2AllPer': 0.3,
                     'c0AllPer': 0.4,
                 },
-                'sssBudget': [{
+                'sssBudgets': [{
                     'familyCode': 'a1i0p0s0t0',
                     'housing': 0.1,
                     'childcare': 0.2,
@@ -276,7 +276,7 @@ class PopulationTestCase(ApiTestCase):
             }]
         })
 
-    def test_population_all_counties(self):
+    def test_populations_all_counties(self):
         self.db.session.add(models.Population(
             fips=1234,
             population=0.1,
@@ -296,7 +296,7 @@ class PopulationTestCase(ApiTestCase):
             mostcommonfamilytype='a1i0p0s0t0',
             year=2012
         ))
-        self.assert_json_equal('/counties/population', {
+        self.assert_json_equal('/counties/populations', {
             'data': [{
                 'fips': 1234,
                 'population': 0.1,
@@ -374,7 +374,7 @@ class PopulationTestCase(ApiTestCase):
             }]
         })
 
-    def test_sssbudget_all_counties(self):
+    def test_sssbudgets_all_counties(self):
         self.db.session.add(models.SssBudget(
             familycode='a1i0p0s0t0',
             housing=0.1,
@@ -387,7 +387,7 @@ class PopulationTestCase(ApiTestCase):
             fips=1234,
             year=2012
         ))
-        self.assert_json_equal('/counties/sssbudget', {
+        self.assert_json_equal('/counties/sssbudgets', {
             'data': [
                 {
                     'familyCode': 'a1i0p0s0t0',
@@ -452,7 +452,7 @@ class PopulationTestCase(ApiTestCase):
             ]
         })
 
-    def test_puma_all_counties(self):
+    def test_pumas_all_counties(self):
         self.db.session.add(models.Puma(
             fips=1234,
             pumacode=5678,
@@ -461,7 +461,7 @@ class PopulationTestCase(ApiTestCase):
             pumapopulation=0.1,
             pumaweight=0.2
         ))
-        self.assert_json_equal('/counties/puma', {
+        self.assert_json_equal('/counties/pumas', {
             "data": [
                 {
                     "fips": 1234,
@@ -474,51 +474,8 @@ class PopulationTestCase(ApiTestCase):
             ]
         })
 
-    def test_census_household(self):
-        self.db.session.add(models.CensusHousehold(
-            censushouseholdid=1,
-            fips=1234,
-            totalhouseholds=1,
-            totalmarriedfamilyhouseholds=2,
-            totalnonfamilyhouseholds=3,
-            totalunmarriedfamilyhouseholds=4,
-            lowincomesingleparents=5,
-            lowincomemarriedparents=6,
-            lowincomesingleadults=7,
-            marriedaspercenttotal=0.1,
-            lowincomemarriedparentsaspercenttotal=0.2,
-            lowincomemarriedparentsaspercentmarried=0.3,
-            unmarriedaspercenttotal=0.4,
-            lowincomesingleparentsaspercenttotal=0.5,
-            lowincomesingleparentsaspercentunmarried=0.6,
-            nonfamilyaspercenttotal=0.7,
-            lowincomesingleadultsaspercenttotal=0.8,
-            lowincomesingleadultsaspercentnonfamily=0.9,
-        ))
-        self.db.session.commit()
-        self.assert_json_equal('/counties/1234/censushousehold', {
-            "data": {
-                "fips": 1234,
-                "totalHouseholds": 1,
-                "totalMarriedFamilyHouseholds": 2,
-                "totalNonFamilyHouseholds": 3,
-                "totalUnmarriedFamilyHouseholds": 4,
-                "lowIncomeSingleParents": 5,
-                "lowIncomeMarriedParents": 6,
-                "lowIncomeSingleAdults": 7,
-                "marriedAsPercentTotal": 0.1,
-                "lowIncomeMarriedParentsAsPercentTotal": 0.2,
-                "lowIncomeMarriedParentsAsPercentMarried": 0.3,
-                "unmarriedAsPercentTotal": 0.4,
-                "lowIncomeSingleParentsAsPercentTotal": 0.5,
-                "lowIncomeSingleParentsAsPercentUnmarried": 0.6,
-                "nonFamilyAsPercentTotal": 0.7,
-                "lowIncomeSingleAdultsAsPercentTotal": 0.8,
-                "lowIncomeSingleAdultsAsPercentNonFamily": 0.9,
-            }
-        })
 
-    def test_census_household_all_counties(self):
+    def test_censushouseholds_all_counties(self):
         self.db.session.add(models.CensusHousehold(
             censushouseholdid=1,
             fips=1234,
@@ -540,7 +497,7 @@ class PopulationTestCase(ApiTestCase):
             lowincomesingleadultsaspercentnonfamily=0.9,
         ))
         self.db.session.commit()
-        self.assert_json_equal('/counties/censushousehold', {
+        self.assert_json_equal('/counties/censushouseholds', {
             "data": [{
                 "fips": 1234,
                 "totalHouseholds": 1,
@@ -560,6 +517,50 @@ class PopulationTestCase(ApiTestCase):
                 "lowIncomeSingleAdultsAsPercentTotal": 0.8,
                 "lowIncomeSingleAdultsAsPercentNonFamily": 0.9,
             }]
+        })
+
+    def test_censushouseholds_for_county(self):
+        self.db.session.add(models.CensusHousehold(
+            censushouseholdid=1,
+            fips=1234,
+            totalhouseholds=1,
+            totalmarriedfamilyhouseholds=2,
+            totalnonfamilyhouseholds=3,
+            totalunmarriedfamilyhouseholds=4,
+            lowincomesingleparents=5,
+            lowincomemarriedparents=6,
+            lowincomesingleadults=7,
+            marriedaspercenttotal=0.1,
+            lowincomemarriedparentsaspercenttotal=0.2,
+            lowincomemarriedparentsaspercentmarried=0.3,
+            unmarriedaspercenttotal=0.4,
+            lowincomesingleparentsaspercenttotal=0.5,
+            lowincomesingleparentsaspercentunmarried=0.6,
+            nonfamilyaspercenttotal=0.7,
+            lowincomesingleadultsaspercenttotal=0.8,
+            lowincomesingleadultsaspercentnonfamily=0.9,
+        ))
+        self.db.session.commit()
+        self.assert_json_equal('/counties/1234/censushouseholds', {
+            "data": {
+                "fips": 1234,
+                "totalHouseholds": 1,
+                "totalMarriedFamilyHouseholds": 2,
+                "totalNonFamilyHouseholds": 3,
+                "totalUnmarriedFamilyHouseholds": 4,
+                "lowIncomeSingleParents": 5,
+                "lowIncomeMarriedParents": 6,
+                "lowIncomeSingleAdults": 7,
+                "marriedAsPercentTotal": 0.1,
+                "lowIncomeMarriedParentsAsPercentTotal": 0.2,
+                "lowIncomeMarriedParentsAsPercentMarried": 0.3,
+                "unmarriedAsPercentTotal": 0.4,
+                "lowIncomeSingleParentsAsPercentTotal": 0.5,
+                "lowIncomeSingleParentsAsPercentUnmarried": 0.6,
+                "nonFamilyAsPercentTotal": 0.7,
+                "lowIncomeSingleAdultsAsPercentTotal": 0.8,
+                "lowIncomeSingleAdultsAsPercentNonFamily": 0.9,
+            }
         })
 
     def test_county_404(self):

--- a/jobs-economy/tests/test_api.py
+++ b/jobs-economy/tests/test_api.py
@@ -34,7 +34,7 @@ class PopulationTestCase(ApiTestCase):
     def test_county_list(self):
         self.db.session.add(models.County(fips=1234, county="Abc"))
         self.db.session.commit()
-        self.assert_json_equal('/counties/', {
+        self.assert_json_equal('/counties', {
             'data': [{
                 'fips': 1234,
                 'name': 'Abc',
@@ -123,9 +123,33 @@ class PopulationTestCase(ApiTestCase):
             fips=1234,
             year=2012
         ))
-
+        self.db.session.add(models.CensusHousehold(
+            censushouseholdid=1,
+            fips=1234,
+            totalhouseholds=1,
+            totalmarriedfamilyhouseholds=2,
+            totalnonfamilyhouseholds=3,
+            totalunmarriedfamilyhouseholds=4,
+            lowincomesingleparents=5,
+            lowincomemarriedparents=6,
+            lowincomesingleadults=7,
+            marriedaspercenttotal=0.1,
+            lowincomemarriedparentsaspercenttotal=0.2,
+            lowincomemarriedparentsaspercentmarried=0.3,
+            unmarriedaspercenttotal=0.4,
+            lowincomesingleparentsaspercenttotal=0.5,
+            lowincomesingleparentsaspercentunmarried=0.6,
+            nonfamilyaspercenttotal=0.7,
+            lowincomesingleadultsaspercenttotal=0.8,
+            lowincomesingleadultsaspercentnonfamily=0.9,
+        ))
+        self.db.session.add(models.FamilyCodeWeight(
+            fips=1234,
+            familycode='a1i0p0s0t0',
+            weight=0.1,
+        ))
         self.db.session.commit()
-        self.assert_json_equal('/counties/1234/', {
+        self.assert_json_equal('/counties/1234', {
             'data': {
                 'laborStats': {
                     'fips': 1234,
@@ -206,6 +230,30 @@ class PopulationTestCase(ApiTestCase):
                     'annual': 0.3,
                     'fips': 1234,
                     'year': 2012
+                }],
+                'censusHouseholds': {
+                    "fips": 1234,
+                    "totalHouseholds": 1,
+                    "totalMarriedFamilyHouseholds": 2,
+                    "totalNonFamilyHouseholds": 3,
+                    "totalUnmarriedFamilyHouseholds": 4,
+                    "lowIncomeSingleParents": 5,
+                    "lowIncomeMarriedParents": 6,
+                    "lowIncomeSingleAdults": 7,
+                    "marriedAsPercentTotal": 0.1,
+                    "lowIncomeMarriedParentsAsPercentTotal": 0.2,
+                    "lowIncomeMarriedParentsAsPercentMarried": 0.3,
+                    "unmarriedAsPercentTotal": 0.4,
+                    "lowIncomeSingleParentsAsPercentTotal": 0.5,
+                    "lowIncomeSingleParentsAsPercentUnmarried": 0.6,
+                    "nonFamilyAsPercentTotal": 0.7,
+                    "lowIncomeSingleAdultsAsPercentTotal": 0.8,
+                    "lowIncomeSingleAdultsAsPercentNonFamily": 0.9,
+                },
+                'familyCodeWeights': [{
+                    "fips": 1234,
+                    "familyCode": "a1i0p0s0t0",
+                    "weight": 0.1,
                 }]
             }
         })


### PR DESCRIPTION
I pluralized all of the resource names and corresponding function names, and updated the CensusHousehold model fields. I'm not messing with the original model names or database table names.
